### PR TITLE
Indexing fix: buildIndex() was leading to corrupted index values when more than one field was index

### DIFF
--- a/src/CRUD.js
+++ b/src/CRUD.js
@@ -251,9 +251,10 @@
    * @param {Object} obj - entry to build index of
    */
   Database.prototype.buildIndex = function ( obj ) {
-    var key, index, value = [obj[this.conf.uniqueKey]];
+    var key, index, value;
     for (var property in obj) {
       if (this.conf.indexedKeys.indexOf(property) !== -1) {
+        value = [obj[this.conf.uniqueKey]];
         key = property + ':' + obj[property];
         index = this.conf.driver.getItem(key);
         if (index !== null) {


### PR DESCRIPTION
Hi Hugo, congrats for this great library, the way your approach secondary indexing in the context of localStorage is very smart.
I have found a small issue with indexes though: If more than one field is indexed, the buildIndex() function creates a corrupted value for indexes beyond the first one.

Example:
var db = new Database( { name: "test", indexedKeys: [ "shape", "color" ] );

After having inserted a few items and you change the "color" attribute of one of them the "test:color:*" records of localStorage become wrong.

The fix corrects this.

Cordially,

Mikael
